### PR TITLE
Prometheus fixes

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -328,9 +328,13 @@ setInterval(() => {
   Object.entries(controlConnections).forEach(([, connection]) => {
     const origin = connection?.origin || 'Unknown';
     connectedDevices += 1;
-    deviceMemoryFree.labels(origin).set(connection.lastMemory.memFree || 0);
-    deviceMemoryMitm.labels(origin).set(connection.lastMemory.memMitm || 0);
-    deviceMemoryStart.labels(origin).set(connection.lastMemory.memStart || 0);
+
+    const validMemFree = Number.isFinite(connection.lastMemory.memFree) ? connection.lastMemory.memFree : 0;
+    deviceMemoryFree.labels(origin).set(validMemFree);
+    const validMemMitm = Number.isFinite(connection.lastMemory.memMitm) ? connection.lastMemory.memMitm : 0;
+    deviceMemoryMitm.labels(origin).set(validMemMitm);
+    const validMemStart = Number.isFinite(connection.lastMemory.memStart) ? connection.lastMemory.memStart : 0;
+    deviceMemoryStart.labels(origin).set(validMemStart);
   });
   // set number of active devices (couldn't get it correct with add/removal signals ; missed some decrement)
   devicesGauge.set(connectedDevices);
@@ -349,7 +353,8 @@ setInterval(() => {
 
   // set workers
   Object.entries(originActiveWorkers).forEach(([name, number]) => {
-    workersGauge.labels(name).set(number || 0);
+    const validNumber = Number.isFinite(number) ? number : 0;
+    workersGauge.labels(name).set(validNumber);
   });
 }, 5000);
 


### PR DESCRIPTION
Possibly solve

```
TypeError: Value is not a valid number: undefined
    at set (/home/rotom/node_modules/prom-client/lib/gauge.js:144:9)
    at Gauge.set (/home/rotom/node_modules/prom-client/lib/gauge.js:30:3)
    at forEach (/home/rotom/dist/packages/server/webpack:/rotom/packages/server/src/index.ts:292:41)
    at Array.forEach (<anonymous>)
    at Timeout._onTimeout (/home/rotom/dist/packages/server/webpack:/rotom/packages/server/src/index.ts:288:38)
    at listOnTimeout (node:internal/timers:569:17)
    at processTimers (node:internal/timers:512:7)
TypeError: Value is not a valid number: undefined
    at set (/home/rotom/node_modules/prom-client/lib/gauge.js:144:9)
    at Gauge.set (/home/rotom/node_modules/prom-client/lib/gauge.js:30:3)
    at forEach (/home/rotom/dist/packages/server/webpack:/rotom/packages/server/src/index.ts:292:41)
    at Array.forEach (<anonymous>)
    at Timeout._onTimeout (/home/rotom/dist/packages/server/webpack:/rotom/packages/server/src/index.ts:288:38)
    at listOnTimeout (node:internal/timers:569:17)
    at processTimers (node:internal/timers:512:7) Uncaught Exception thrown
2023-11-20 22:14:51.923  ERROR TypeError: Value is not a valid number: undefined
    at set (/home/rotom/node_modules/prom-client/lib/gauge.js:144:9)
    at Gauge.set (/home/rotom/node_modules/prom-client/lib/gauge.js:30:3)
    at forEach (/home/rotom/dist/packages/server/webpack:/rotom/packages/server/src/index.ts:292:41)
    at Array.forEach (<anonymous>)
    at Timeout._onTimeout (/home/rotom/dist/packages/server/webpack:/rotom/packages/server/src/index.ts:288:38)
    at listOnTimeout (node:internal/timers:569:17)
    at processTimers (node:internal/timers:512:7) Uncaught Exception thrown 
```