### PR TITLE
Prefix custom metrics with `rotom_` as per naming best practices

### DIFF
--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -3,35 +3,37 @@ import { Registry, collectDefaultMetrics, Gauge } from 'prom-client';
 export const promRegistry = new Registry();
 collectDefaultMetrics({ register: promRegistry });
 
+const prefix = 'rotom_';
+
 export const devicesGauge = new Gauge({
-  name: 'devices',
+  name: prefix + 'devices',
   help: 'Devices in use',
   registers: [promRegistry],
 });
 
 export const workersGauge = new Gauge({
-  name: 'workers',
+  name: prefix + 'workers',
   help: 'Workers in use',
   labelNames: ['origin'],
   registers: [promRegistry],
 });
 
 export const deviceMemoryFree = new Gauge({
-  name: 'device_memory_free',
+  name: prefix + 'device_memory_free',
   help: 'Device Memory Free',
   labelNames: ['origin'],
   registers: [promRegistry],
 });
 
 export const deviceMemoryMitm = new Gauge({
-  name: 'device_memory_mitm',
+  name: prefix + 'device_memory_mitm',
   help: 'Device Memory MITM',
   labelNames: ['origin'],
   registers: [promRegistry],
 });
 
 export const deviceMemoryStart = new Gauge({
-  name: 'device_memory_start',
+  name: prefix + 'device_memory_start',
   help: 'Device Memory Start',
   labelNames: ['origin'],
   registers: [promRegistry],


### PR DESCRIPTION
As per Prometheus naming best practices (https://prometheus.io/docs/practices/naming/) and as discussed in Discord, custom metrics should ideally be prefixed with the name of the software. Especially `devices` vs. `rotom_devices` makes for easier discoverability and deduping without custom upstream labeling.
