### PR TITLE
Fix: `rotom_devices_alive` & `rotom_workers_active` reflect isAlive, `_totals` version that doesn't.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:18 AS build-env
-COPY . /app
+COPY package.json package-lock.json /app/
 WORKDIR /app
 
 RUN npm ci --no-save
+COPY . /app
 RUN npm run build
 # re-install without dev dependencies
 RUN npm ci --omit=dev

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -328,7 +328,6 @@ setInterval(() => {
   let totalDevices = 0;
 
   Object.entries(controlConnections).forEach(([, connection]) => {
-    const origin = connection?.origin || 'Unknown';
     totalDevices += 1;
   });
   // set memory for alive devices, but first reset to get rid of dropped origins

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -85,8 +85,8 @@ wssMitm.on('connection', (ws, req) => {
             restartRequired = true;
           }
           if (memoryStatus.memStart) {
-            const prefix = Object.keys(config.monitor.maxMemStartMultipleOverwrite).find(
-              (key) => mitm.origin?.startsWith(key),
+            const prefix = Object.keys(config.monitor.maxMemStartMultipleOverwrite).find((key) =>
+              mitm.origin?.startsWith(key),
             );
 
             const value = prefix
@@ -325,11 +325,7 @@ if (config.logging.consoleStatus) {
 // This is not the Best way to do this, but previous attemps at active tracking via events have failed
 setInterval(() => {
   let connectedDevices = 0;
-  let totalDevices = 0;
 
-  Object.entries(controlConnections).forEach(([, connection]) => {
-    totalDevices += 1;
-  });
   // set memory for alive devices, but first reset to get rid of dropped origins
   deviceMemoryFree.reset();
   deviceMemoryMitm.reset();
@@ -347,8 +343,10 @@ setInterval(() => {
       const validMemStart = Number.isFinite(connection.lastMemory.memStart) ? connection.lastMemory.memStart : 0;
       deviceMemoryStart.labels(origin).set(validMemStart);
     });
+
+  // Set device counts
+  devicesTotalGauge.set(Object.keys(controlConnections).length);
   devicesAliveGauge.set(connectedDevices);
-  devicesTotalGauge.set(totalDevices);
 
   // fetch active workers
   const originActiveWorkers: Record<string, number> = {};

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -8,7 +8,7 @@ import { StatusDTO, WorkerDTO, JobsDTO, JobsStatusDTO } from '@rotom/types';
 import {
   promRegistry,
   workersTotalGauge,
-  workersAliveGauge,
+  workersActiveGauge,
   devicesTotalGauge,
   devicesAliveGauge,
   deviceMemoryFree,
@@ -368,14 +368,14 @@ setInterval(() => {
 
   // set workers, but first reset to get rid of dropped origins
   workersTotalGauge.reset();
-  workersAliveGauge.reset();
+  workersActiveGauge.reset();
   Object.entries(originTotalWorkers).forEach(([name, number]) => {
     const validNumber = Number.isFinite(number) ? number : 0;
     workersTotalGauge.labels(name).set(validNumber);
   });
   Object.entries(originActiveWorkers).forEach(([name, number]) => {
     const validNumber = Number.isFinite(number) ? number : 0;
-    workersAliveGauge.labels(name).set(validNumber);
+    workersActiveGauge.labels(name).set(validNumber);
   });
 }, 5000);
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -38,6 +38,10 @@ process
     log.error(`${inspect(err)} Uncaught Exception thrown`);
 
     process.exit(1);
+  })
+  .on('SIGINT', function() {
+    console.log("Caught interrupt signal");
+    process.exit();
   });
 
 wssMitm.on('connection', (ws, req) => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -344,12 +344,13 @@ setInterval(() => {
     if (!(origin in originActiveWorkers)) {
       originActiveWorkers[origin] = 0;
     }
-    if (connection.scanner) {
+    if (connection.scanner && connection.scanner.isAlive && connection.mitm.isAlive) {
       originActiveWorkers[origin] += 1;
     }
   });
 
   // set workers
+  workersGauge.reset(); // Otherwise dropped devices stay stale
   Object.entries(originActiveWorkers).forEach(([name, number]) => {
     const validNumber = Number.isFinite(number) ? number : 0;
     workersGauge.labels(name).set(validNumber);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -323,7 +323,7 @@ if (config.logging.consoleStatus) {
 setInterval(() => {
   let connectedDevices = 0;
   // set memory
-  Object.entries(controlConnections).forEach(([, connection]) => {
+  Object.entries(controlConnections).filter(([, connection]) => connection.isAlive).forEach(([, connection]) => {
     const origin = connection?.origin || 'Unknown';
     connectedDevices += 1;
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -39,8 +39,8 @@ process
 
     process.exit(1);
   })
-  .on('SIGINT', function() {
-    console.log("Caught interrupt signal");
+  .on('SIGINT', function () {
+    console.log('Caught interrupt signal');
     process.exit();
   });
 
@@ -323,17 +323,19 @@ if (config.logging.consoleStatus) {
 setInterval(() => {
   let connectedDevices = 0;
   // set memory
-  Object.entries(controlConnections).filter(([, connection]) => connection.isAlive).forEach(([, connection]) => {
-    const origin = connection?.origin || 'Unknown';
-    connectedDevices += 1;
+  Object.entries(controlConnections)
+    .filter(([, connection]) => connection.isAlive)
+    .forEach(([, connection]) => {
+      const origin = connection?.origin || 'Unknown';
+      connectedDevices += 1;
 
-    const validMemFree = Number.isFinite(connection.lastMemory.memFree) ? connection.lastMemory.memFree : 0;
-    deviceMemoryFree.labels(origin).set(validMemFree);
-    const validMemMitm = Number.isFinite(connection.lastMemory.memMitm) ? connection.lastMemory.memMitm : 0;
-    deviceMemoryMitm.labels(origin).set(validMemMitm);
-    const validMemStart = Number.isFinite(connection.lastMemory.memStart) ? connection.lastMemory.memStart : 0;
-    deviceMemoryStart.labels(origin).set(validMemStart);
-  });
+      const validMemFree = Number.isFinite(connection.lastMemory.memFree) ? connection.lastMemory.memFree : 0;
+      deviceMemoryFree.labels(origin).set(validMemFree);
+      const validMemMitm = Number.isFinite(connection.lastMemory.memMitm) ? connection.lastMemory.memMitm : 0;
+      deviceMemoryMitm.labels(origin).set(validMemMitm);
+      const validMemStart = Number.isFinite(connection.lastMemory.memStart) ? connection.lastMemory.memStart : 0;
+      deviceMemoryStart.labels(origin).set(validMemStart);
+    });
   // set number of active devices (couldn't get it correct with add/removal signals ; missed some decrement)
   devicesGauge.set(connectedDevices);
 

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -5,15 +5,28 @@ collectDefaultMetrics({ register: promRegistry });
 
 const prefix = 'rotom_';
 
-export const devicesGauge = new Gauge({
-  name: prefix + 'devices',
-  help: 'Devices in use',
+export const devicesTotalGauge = new Gauge({
+  name: prefix + 'devices_total',
+  help: 'Devices known regardless of state',
   registers: [promRegistry],
 });
 
-export const workersGauge = new Gauge({
-  name: prefix + 'workers',
-  help: 'Workers in use',
+export const devicesAliveGauge = new Gauge({
+  name: prefix + 'devices_alive',
+  help: 'Devices that pass isAlive',
+  registers: [promRegistry],
+});
+
+export const workersTotalGauge = new Gauge({
+  name: prefix + 'workers_total',
+  help: 'Workers known regardless of state',
+  labelNames: ['origin'],
+  registers: [promRegistry],
+});
+
+export const workersAliveGauge = new Gauge({
+  name: prefix + 'workers_alive',
+  help: 'Workers that pass isAlive',
   labelNames: ['origin'],
   registers: [promRegistry],
 });

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -24,9 +24,9 @@ export const workersTotalGauge = new Gauge({
   registers: [promRegistry],
 });
 
-export const workersAliveGauge = new Gauge({
-  name: prefix + 'workers_alive',
-  help: 'Workers that pass isAlive',
+export const workersActiveGauge = new Gauge({
+  name: prefix + 'workers_active',
+  help: 'Workers that have an active mitm connection',
   labelNames: ['origin'],
   registers: [promRegistry],
 });


### PR DESCRIPTION
- Split `rotom_devices` metric to `rotom_devices_total` & `rotom_devices_alive`.
- Same treatment for `rotom_workers_total` & `rotom_workers_active`

Also, dev flow improvements:
- Docker: run npm-ci with less context to cache it better
- Exit the server on the interrupt signal