### PR TITLE
feat: remove all dead devices button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,9 +85,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
-      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
+      "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==",
       "dev": true
     },
     "node_modules/@ampproject/remapping": {
@@ -19709,9 +19709,9 @@
       "dev": true
     },
     "@adobe/css-tools": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
-      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
+      "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==",
       "dev": true
     },
     "@ampproject/remapping": {

--- a/packages/client/src/app/status/statusPage.tsx
+++ b/packages/client/src/app/status/statusPage.tsx
@@ -20,7 +20,7 @@ export const StatusPage = (): JSX.Element => {
     const cancel = new AbortController();
     const timer = setTimeout(() => cancel.abort(), 5000);
     try {
-      await fetch('/api/device/delete', { method: 'DELETE', signal: cancel.signal });
+      await fetch('/api/device', { method: 'DELETE', signal: cancel.signal });
     } catch (e) {
       console.error(e);
     } finally {

--- a/packages/client/src/app/status/statusPage.tsx
+++ b/packages/client/src/app/status/statusPage.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
-import { Loading, Spacer, Text } from '@nextui-org/react';
+import { Button, Grid, Loading, Spacer, Text } from '@nextui-org/react';
 import { StatusDTO } from '@rotom/types';
+import { useCallback, useState } from 'react';
 
 import { StatusCard } from './statusCard';
 import { MemoizedWorkersTable as WorkersTable } from './workersTable';
@@ -12,6 +13,21 @@ export const StatusPage = (): JSX.Element => {
   const { isLoading, isFetching, error, data, isSuccess } = useQuery<StatusDTO, Error>(['status'], fetchStatus, {
     refetchInterval: 5000,
   });
+  const [delLoading, setDelLoading] = useState(false);
+
+  const handleRemoveDead = useCallback(async () => {
+    setDelLoading(true);
+    const cancel = new AbortController();
+    const timer = setTimeout(() => cancel.abort(), 5000);
+    try {
+      await fetch('/api/device/delete', { method: 'DELETE', signal: cancel.signal });
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setDelLoading(false);
+      clearTimeout(timer);
+    }
+  }, []);
 
   if (isLoading) {
     return <Loading />;
@@ -30,7 +46,16 @@ export const StatusPage = (): JSX.Element => {
       </Text>
       <StatusCard {...data} />
       <Spacer y={1} />
-      <Text h3>Devices</Text>
+      <Grid.Container justify="space-between" alignItems="center">
+        <Grid>
+          <Text h3>Devices</Text>
+        </Grid>
+        <Grid>
+          <Button auto color="error" size="sm" onClick={handleRemoveDead}>
+            {delLoading ? <Loading /> : 'Remove Dead'}
+          </Button>
+        </Grid>
+      </Grid.Container>
       <DevicesTable devices={data.devices} workers={data.workers} />
       <Spacer y={1} />
       <Text h3>Workers</Text>

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -465,6 +465,7 @@ const routes = async (fastifyInstance: FastifyInstance) => {
   });
 
   fastifyInstance.delete('/api/device', async (request, reply) => {
+    log.info('Received delete all devices request');
     const deviceIds = Object.keys(controlConnections);
     let deleted = 0;
     for (const deviceId of deviceIds) {
@@ -475,6 +476,7 @@ const routes = async (fastifyInstance: FastifyInstance) => {
         deleted++;
       }
     }
+    log.info(`Deleted ${deleted} devices`);
     return reply.code(200).send({ status: 'ok', error: `Deleted ${deleted} devices` });
   });
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -464,6 +464,20 @@ const routes = async (fastifyInstance: FastifyInstance) => {
     }
   });
 
+  fastifyInstance.delete('/api/device', async (request, reply) => {
+    const deviceIds = Object.keys(controlConnections);
+    let deleted = 0;
+    for (const deviceId of deviceIds) {
+      const device = controlConnections[deviceId];
+      if (!device.isAlive) {
+        delete deviceInformation[deviceId];
+        delete controlConnections[deviceId];
+        deleted++;
+      }
+    }
+    return reply.code(200).send({ status: 'ok', error: `Deleted ${deleted} devices` });
+  });
+
   interface ActionExecuteParams {
     deviceId: keyof typeof controlConnections;
     action: 'restart' | 'reboot' | 'getLogcat' | 'delete';


### PR DESCRIPTION
This adds a button to the status page (and the respective route to the server) that deletes all dead devices in one go.

(Also updates the dependency that had an audit warning)