### PR TITLE
Fix sending job to all devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:server": "nx run server:dev",
     "lint": "nx run-many --target=lint --all",
     "start": "node dist/packages/server/main.js",
-    "test": "NODE_ENV=development NX_ENABLE_MOCKS=1 nx run-many --target=dev --all",
+    "dev:mock": "NODE_ENV=development NX_ENABLE_MOCKS=1 nx run-many --target=dev --all",
     "clear-cache": "nx clear-cache"
   },
   "volta": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev:server": "nx run server:dev",
     "lint": "nx run-many --target=lint --all",
     "start": "node dist/packages/server/main.js",
+    "test": "NODE_ENV=development NX_ENABLE_MOCKS=1 nx run-many --target=dev --all",
     "clear-cache": "nx clear-cache"
   },
   "volta": {

--- a/packages/client/src/app/jobs/executeJobModal.tsx
+++ b/packages/client/src/app/jobs/executeJobModal.tsx
@@ -17,6 +17,9 @@ export const ExecuteJobModal = ({ closeModal, devices, jobId }: ExecuteJobModalP
     async ({ deviceIds }: { deviceIds: string[] | number[] }) => {
       const promise = fetch(`/api/job/execute/${jobId}`, {
         method: 'POST',
+        headers: {
+          'Content-Type': 'application/json', // Set the Content-Type header to application/json
+        },
         body: JSON.stringify({ deviceIdsOrOrigins: deviceIds }),
       }).then(async (response) => {
         if (response.status !== 200) {

--- a/packages/client/src/app/jobs/executeJobModal.tsx
+++ b/packages/client/src/app/jobs/executeJobModal.tsx
@@ -18,7 +18,7 @@ export const ExecuteJobModal = ({ closeModal, devices, jobId }: ExecuteJobModalP
       const promise = fetch(`/api/job/execute/${jobId}`, {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json', // Set the Content-Type header to application/json
+          'Content-Type': 'application/json', // fastify is only able to parse the body to a project with this header
         },
         body: JSON.stringify({ deviceIdsOrOrigins: deviceIds }),
       }).then(async (response) => {

--- a/packages/client/src/app/jobs/executeJobModal.tsx
+++ b/packages/client/src/app/jobs/executeJobModal.tsx
@@ -15,19 +15,19 @@ export const ExecuteJobModal = ({ closeModal, devices, jobId }: ExecuteJobModalP
 
   const executeJob = useCallback(
     async ({ deviceIds }: { deviceIds: string[] | number[] }) => {
-      const promise = fetch(`/api/job/execute/${jobId}/${deviceIds.join()}`, { method: 'POST' }).then(
-        async (response) => {
-          if (response.status !== 200) {
-            throw new Error();
-          }
-
-          closeModal();
-        },
-      );
+      const promise = fetch(`/api/job/execute/${jobId}`, {
+        method: 'POST',
+        body: JSON.stringify({ deviceIdsOrOrigins: deviceIds }),
+      }).then(async (response) => {
+        if (response.status !== 200) {
+          throw new Error();
+        }
+        closeModal();
+      });
 
       toast.promise(promise, {
         pending: `Running ${jobId}...`,
-        success: `${jobId} started succesfully`,
+        success: `${jobId} started successfully`,
         error: `Failed to start job ${jobId}`,
       });
     },

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -537,7 +537,11 @@ const routes = async (fastifyInstance: FastifyInstance) => {
     jobId: string;
   }
 
-  fastifyInstance.post<{ Params: JobExecuteParams; Body: { deviceIdsOrOrigins?: string[] | number[] } }>(
+  interface DeviceIdsOrOriginsBody {
+    deviceIdsOrOrigins?: string[] | number[];
+  }
+
+  fastifyInstance.post<{ Params: JobExecuteParams; Body: DeviceIdsOrOriginsBody }>(
     '/api/job/execute/:jobId/:deviceIdsOrOrigins?',
     async (req, reply) => {
       const { deviceIdsOrOrigins, jobId } = req.params;


### PR DESCRIPTION
resolves #20 

Due to a restriction to length of a param in the url this caused an error (404 NOT FOUND)