### PR TITLE
Logging Adjustments

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -15,7 +15,7 @@
     "save": false,
     "maxSize": 100,
     "maxAge": 14,
-    "debug": false,
+    "level": "info",
     "consoleStatus": false
   },
   "monitor": {

--- a/packages/client/src/app/layout.tsx
+++ b/packages/client/src/app/layout.tsx
@@ -14,7 +14,6 @@ const NavbarLink = ({ children, to }: { children?: ReactNode; to: string }): JSX
 
   const location = useLocation();
   const isActive = location.pathname === to;
-  console.log({ location, to, isActive });
 
   return (
     <Navbar.Link

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -17,7 +17,7 @@ interface Config {
     save: boolean;
     maxSize: number;
     maxAge: number;
-    debug: boolean;
+    level: string;
     consoleStatus: boolean;
   };
   monitor: {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -47,6 +47,7 @@ process
   })
   .on('SIGINT', function () {
     console.log('Caught interrupt signal');
+    log.info('Caught interrupt signal');
     process.exit();
   });
 
@@ -168,7 +169,7 @@ wssDevice.on('connection', (ws, req) => {
     const workerId = deviceWorker.workerId as string;
     const instanceNo = deviceWorker.instanceNo;
 
-    console.log(`${workerId}/${instanceNo}: Disconnected; performing disconnection activities`);
+    log.info(`${workerId}/${instanceNo}: Disconnected; performing disconnection activities`);
     if (workerId) {
       const currentConnection = currentConnections[workerId];
       if (currentConnection) {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -155,7 +155,13 @@ wssDevice.on('connection', (ws, req) => {
       controller: null,
     };
     if (!unallocatedConnections.includes(workerId)) unallocatedConnections.push(workerId);
-    log.info(`${workerId}: unallocated connections = ${unallocatedConnections.join(',')}`);
+    log.info(
+      `${workerId}: unallocated connections = ${
+        unallocatedConnections.length > 10
+          ? unallocatedConnections.length.toLocaleString()
+          : unallocatedConnections.join(', ')
+      }`,
+    );
   });
 
   deviceConnection.on('disconnected', (deviceWorker: DeviceWorkerConnection) => {
@@ -183,7 +189,13 @@ wssDevice.on('connection', (ws, req) => {
       for (let index = unallocatedConnections.length - 1; index >= 0; index--) {
         if (unallocatedConnections[index] === workerId) unallocatedConnections.splice(index, 1);
       }
-      log.info(`${workerId}: unallocated connections = ${unallocatedConnections.join(',')}`);
+      log.info(
+        `${workerId}: unallocated connections = ${
+          unallocatedConnections.length > 10
+            ? unallocatedConnections.length.toLocaleString()
+            : unallocatedConnections.join(', ')
+        }`,
+      );
     }
   });
 });

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -24,7 +24,7 @@ if (config.logging.save) {
 transports.push(new winston.transports.Console());
 
 export const log = winston.createLogger({
-  level: config.logging && config.logging.debug ? 'debug' : 'info',
+  level: config.logging && config.logging.level in winston.config.npm.levels ? config.logging.level : 'info',
   format: winston.format.combine(winston.format.timestamp(), winston.format.label({ label: 'rotom' }), logFormat),
   transports: transports,
 });


### PR DESCRIPTION
## Changes
- Limits the size of the `unallocated workers` log by printing the length instead of EVERY worker name if there's more than 10
- Removes an unnecessary log in the client
- Replaces a console.log with a log.info 
- Allows the log level to be configurable, does a key check to make sure a valid one is set by the user, otherwise uses `info`

## Reasoning
The current info level logs in Rotom are totally unnecessary for users not debugging issues and are actively causing issues for setups with 5,000+ workers due to the extremely excessive amount of logging being done.