### PR TITLE
Add worker version column in workersTable for easier App/Agent versio…

### DIFF
--- a/packages/client/src/app/status/workersTable.tsx
+++ b/packages/client/src/app/status/workersTable.tsx
@@ -44,11 +44,11 @@ export const WorkersTable = ({ workers }: { workers: StatusDTO['workers'] }): JS
           <Table.Column key="workerId" allowsSorting>
             Worker Id
           </Table.Column>
-          <Table.Column key="workerVersion" allowsSorting>
-            Version
-          </Table.Column>
           <Table.Column key="isAllocated" allowsSorting>
             Is Active
+          </Table.Column>
+          <Table.Column key="workerVersion" allowsSorting>
+            Version
           </Table.Column>
           <Table.Column key="scanner.workerName" allowsSorting>
             Scanner Worker Name

--- a/packages/client/src/app/status/workersTable.tsx
+++ b/packages/client/src/app/status/workersTable.tsx
@@ -65,8 +65,8 @@ export const WorkersTable = ({ workers }: { workers: StatusDTO['workers'] }): JS
             <Table.Row key={`${worker.workerId}-${index}`}>
               <Table.Cell>{worker.worker.origin}</Table.Cell>
               <Table.Cell>{worker.workerId}</Table.Cell>
-              <Table.Cell>{worker.worker.version}</Table.Cell>
               <Table.Cell>{worker.isAllocated ? '✅' : '❌'}</Table.Cell>
+              <Table.Cell>{worker.worker.version}</Table.Cell>
               <Table.Cell>{worker.controller?.workerName}</Table.Cell>
               <Table.Cell>
                 <RelativeTimeLabel timestamp={worker.worker.dateLastMessageReceived} />

--- a/packages/client/src/app/status/workersTable.tsx
+++ b/packages/client/src/app/status/workersTable.tsx
@@ -44,6 +44,9 @@ export const WorkersTable = ({ workers }: { workers: StatusDTO['workers'] }): JS
           <Table.Column key="workerId" allowsSorting>
             Worker Id
           </Table.Column>
+          <Table.Column key="workerVersion" allowsSorting>
+            Version
+          </Table.Column>
           <Table.Column key="isAllocated" allowsSorting>
             Is Active
           </Table.Column>
@@ -62,6 +65,7 @@ export const WorkersTable = ({ workers }: { workers: StatusDTO['workers'] }): JS
             <Table.Row key={`${worker.workerId}-${index}`}>
               <Table.Cell>{worker.worker.origin}</Table.Cell>
               <Table.Cell>{worker.workerId}</Table.Cell>
+              <Table.Cell>{worker.worker.version}</Table.Cell>
               <Table.Cell>{worker.isAllocated ? '✅' : '❌'}</Table.Cell>
               <Table.Cell>{worker.controller?.workerName}</Table.Cell>
               <Table.Cell>


### PR DESCRIPTION
…n control/overview

Pokemod MITM Aegis works with App and Agent versions which are independent of each other. Agent versions are pushed server side while App versions have to be installed by the user. Since Rotom already demands version_code to be sent in the Welcome Message, the worker version is present and can be displayed in the worker's table to make it easier for the user to see exactly on what version each of his device is working and with this PR it will also allow to see if each device has the latest agent deployed (which are only deployed on restart) as in this screenshot:

![image](https://github.com/UnownHash/Rotom/assets/47287506/1e23fd5a-58dc-4cd3-ac0c-f130f317a465)
