### PR TITLE
Disable memory monitor and device cooldown

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -19,11 +19,11 @@
     "consoleStatus": false
   },
   "monitor": {
-    "enabled": true,
+    "enabled": false,
     "reboot": false,
     "minMemory": 30000,
     "maxMemStartMultiple": 2,
     "maxMemStartMultipleOverwrite": {},
-    "deviceCooldown": 20
+    "deviceCooldown": 0
   }
 }


### PR DESCRIPTION
* Change memory default to false as per discussion #35 
* Change device cooldown to 0
As far as I know all public MITMs have their own implementation for cooldown per device.