### PR TITLE
Add sorting of devices by load

### DIFF
--- a/packages/client/src/app/server.ts
+++ b/packages/client/src/app/server.ts
@@ -19,8 +19,9 @@ export const makeServer = ({ environment = 'test' } = {}) => {
     },
 
     seeds(server) {
-      server.createList('device', 10);
-      server.createList('worker', 50);
+      server.createList('device', 10).forEach((device) => {
+        server.createList('worker', 5, { deviceId: device.deviceId });
+      });
     },
 
     factories: {

--- a/packages/client/src/app/status/devicesTable.tsx
+++ b/packages/client/src/app/status/devicesTable.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useMemo, useState } from 'react';
-import { StatusDTO, DeviceControlDTO } from '@rotom/types';
+import { DeviceWithLoadDTO, TransformedStatusDTO } from '@rotom/types';
 import { Table, Dropdown, SortDescriptor } from '@nextui-org/react';
 import { toast } from 'react-toastify';
 
@@ -12,7 +12,7 @@ const kBNumberFormat = new Intl.NumberFormat('en', { style: 'unit', unit: 'kilob
 
 const initialSortDescriptor: SortDescriptor = { column: 'origin', direction: 'ascending' };
 
-export const DevicesTable = ({ devices, workers }: StatusDTO): JSX.Element => {
+export const DevicesTable = ({ devices }: TransformedStatusDTO): JSX.Element => {
   const [search, setSearch] = useState('');
   const executeAction = useCallback(
     async ({ deviceId, action }: { deviceId: string; action: 'reboot' | 'restart' | 'getLogcat' | 'delete' }) => {
@@ -57,7 +57,7 @@ export const DevicesTable = ({ devices, workers }: StatusDTO): JSX.Element => {
     [],
   );
 
-  const list = useTableSort<DeviceControlDTO>({
+  const list = useTableSort<DeviceWithLoadDTO>({
     items: devices,
     initialSortDescriptor,
   });
@@ -87,7 +87,7 @@ export const DevicesTable = ({ devices, workers }: StatusDTO): JSX.Element => {
           <Table.Column key="origin" allowsSorting>
             Origin
           </Table.Column>
-          <Table.Column key="load" allowsSorting>
+          <Table.Column key="load.percent" allowsSorting width={56}>
             Load
           </Table.Column>
           <Table.Column key="deviceId" allowsSorting>
@@ -118,13 +118,11 @@ export const DevicesTable = ({ devices, workers }: StatusDTO): JSX.Element => {
         </Table.Header>
         <Table.Body loadingState={list.loadingState}>
           {filteredItems.map((device, index) => {
-            const deviceWorkers = workers.filter((worker) => worker.deviceId === device.deviceId);
-
             return (
               <Table.Row key={`${device.deviceId}-${index}`}>
                 <Table.Cell>{device.origin}</Table.Cell>
                 <Table.Cell>
-                  {deviceWorkers.filter((worker) => worker.isAllocated).length}/{deviceWorkers.length}
+                  {device.load.allocated}/{device.load.total}
                 </Table.Cell>
                 <Table.Cell>{device.deviceId}</Table.Cell>
                 <Table.Cell>{device.isAlive ? '✅' : '❌'}</Table.Cell>

--- a/packages/types/src/status.ts
+++ b/packages/types/src/status.ts
@@ -14,3 +14,15 @@ export interface StatusDTO {
   workers: WorkerDTO[];
   devices: DeviceControlDTO[];
 }
+
+export type DeviceWithLoadDTO = DeviceControlDTO & {
+  load: {
+    percent: number;
+    allocated: number;
+    total: number;
+  };
+};
+
+export interface TransformedStatusDTO extends StatusDTO {
+  devices: DeviceWithLoadDTO[];
+}


### PR DESCRIPTION
A small feature to enable sorting of devices by load. This would help people that want to find their devices that are still online but with offline workers. All the computation of the load of the device is made on the client side. Which mean it's possible to run the mocked Rotom to test this feature. 