### PR TITLE
Switch isAlive to be connection status

### DIFF
--- a/packages/client/src/app/server.ts
+++ b/packages/client/src/app/server.ts
@@ -38,6 +38,9 @@ export const makeServer = ({ environment = 'test' } = {}) => {
         isAlive() {
           return faker.datatype.boolean();
         },
+        heartbeatCheckStatus() {
+          return faker.datatype.boolean();
+        },
         lastMemory() {
           return {
             memFree: faker.datatype.number(),
@@ -69,6 +72,7 @@ export const makeServer = ({ environment = 'test' } = {}) => {
             init: faker.datatype.boolean(),
             instanceNo: 0,
             isAlive: faker.datatype.boolean(),
+            heartbeatCheckStatus: faker.datatype.boolean(),
             noMessagesReceived: 1,
             noMessagesSent: 1,
             origin: 'none',

--- a/packages/connections/src/lib/deviceControlConnection.ts
+++ b/packages/connections/src/lib/deviceControlConnection.ts
@@ -40,6 +40,7 @@ export class DeviceControlConnection extends EventEmitter {
   version?: string;
   publicIp?: string;
   ws: WebSocket;
+  heartbeatCheckStatus: boolean;
   isAlive: boolean;
   instanceNo: number;
   heartbeatHandle: NodeJS.Timer;
@@ -52,6 +53,7 @@ export class DeviceControlConnection extends EventEmitter {
     this.log = log;
     this.ws = ws;
     this.init = true;
+    this.heartbeatCheckStatus = true;
     this.isAlive = true;
     this.origin = '';
 
@@ -125,11 +127,11 @@ export class DeviceControlConnection extends EventEmitter {
   }
 
   heartbeat() {
-    this.isAlive = true;
+    this.heartbeatCheckStatus = true;
   }
 
   checkHeartbeat() {
-    if (!this.isAlive) {
+    if (!this.heartbeatCheckStatus) {
       // Pong has not been received in last interval seconds
       this.log.warn(`${this.deviceId}/${this.instanceNo}: DEVICE - No response to ping - forcing disconnect`);
       clearInterval(this.heartbeatHandle);
@@ -138,11 +140,12 @@ export class DeviceControlConnection extends EventEmitter {
       return;
     }
 
-    this.isAlive = false;
+    this.heartbeatCheckStatus = false;
     this.ws.ping();
   }
 
   disconnected() {
+    this.heartbeatCheckStatus = false;
     this.isAlive = false;
     clearInterval(this.heartbeatHandle);
 
@@ -216,6 +219,7 @@ export class DeviceControlConnection extends EventEmitter {
       deviceId: this.deviceId,
       init: this.init,
       instanceNo: this.instanceNo,
+      heartbeatCheckStatus: this.heartbeatCheckStatus,
       isAlive: this.isAlive,
       lastMemory: this.lastMemory,
       nextId: this.nextId,

--- a/packages/connections/src/lib/deviceWorkerConnection.ts
+++ b/packages/connections/src/lib/deviceWorkerConnection.ts
@@ -22,6 +22,7 @@ export class DeviceWorkerConnection extends EventEmitter {
   origin?: string;
   version?: string;
   ws: WebSocket;
+  heartbeatCheckStatus: boolean;
   isAlive: boolean;
   instanceNo: number;
   heartbeatHandle: NodeJS.Timer;
@@ -33,6 +34,7 @@ export class DeviceWorkerConnection extends EventEmitter {
     this.ws = ws;
     this.log = log;
     this.init = true;
+    this.heartbeatCheckStatus = true;
     this.isAlive = true;
     this.origin = '';
     this.traceMessages = false;
@@ -101,11 +103,11 @@ export class DeviceWorkerConnection extends EventEmitter {
   }
 
   heartbeat() {
-    this.isAlive = true;
+    this.heartbeatCheckStatus = true;
   }
 
   checkHeartbeat() {
-    if (!this.isAlive) {
+    if (!this.heartbeatCheckStatus) {
       // Pong has not been received in last interval seconds
       this.log.warn(`${this.workerId}/${this.instanceNo}: MITM - No response to ping - forcing disconnect`);
       clearInterval(this.heartbeatHandle);
@@ -114,12 +116,13 @@ export class DeviceWorkerConnection extends EventEmitter {
       return;
     }
 
-    this.isAlive = false;
+    this.heartbeatCheckStatus = false;
     this.ws.ping();
   }
 
   disconnected() {
-    this.isAlive = false;
+    this.heartbeatCheckStatus = false;
+    this.isAlive = true;
     clearInterval(this.heartbeatHandle);
 
     this.emit('disconnected', this);
@@ -131,6 +134,7 @@ export class DeviceWorkerConnection extends EventEmitter {
       dateLastMessageSent: this.dateLastMessageSent,
       init: this.init,
       instanceNo: this.instanceNo,
+      heartbeatCheckStatus: this.heartbeatCheckStatus,
       isAlive: this.isAlive,
       noMessagesReceived: this.noMessagesReceived,
       noMessagesSent: this.noMessagesSent,

--- a/packages/connections/src/lib/deviceWorkerConnection.ts
+++ b/packages/connections/src/lib/deviceWorkerConnection.ts
@@ -122,7 +122,7 @@ export class DeviceWorkerConnection extends EventEmitter {
 
   disconnected() {
     this.heartbeatCheckStatus = false;
-    this.isAlive = true;
+    this.isAlive = false;
     clearInterval(this.heartbeatHandle);
 
     this.emit('disconnected', this);


### PR DESCRIPTION
This changes isAlive to be a connection status (ie set to false only on disconnection)
The previous isAlive is renamed to heartbeatCheckStatus - this status indicates that a pong is outstanding, and has not very much use externally (though was used before and confused people) 