### PR TITLE
fix: null message crash and drop array messages

### DIFF
--- a/packages/connections/src/lib/deviceControlConnection.ts
+++ b/packages/connections/src/lib/deviceControlConnection.ts
@@ -88,7 +88,7 @@ export class DeviceControlConnection extends EventEmitter {
       // Do nothing
     }
 
-    if (typeof msg !== 'object') {
+    if (typeof msg !== 'object' || Array.isArray(msg) || msg == null) {
       this.log.error(`Device /control - error decoding message, disconnecting`);
       this.ws.close();
       return;

--- a/packages/connections/src/lib/deviceControlConnection.ts
+++ b/packages/connections/src/lib/deviceControlConnection.ts
@@ -164,7 +164,7 @@ export class DeviceControlConnection extends EventEmitter {
     //< {"id":7,"status":200,"body":{"memFree":123, ...}}
 
     const memory = await this.executeCommand<MemoryStatus>('getMemoryUsage', null, 5000);
-    if (typeof memory === 'object') {
+    if (typeof memory === 'object' && !Array.isArray(msg) && msg != null) {
       this.lastMemory = memory; // spy on result
     }
     return memory;


### PR DESCRIPTION
Previously in PR #48, all JSON releated crashes were supposed to be fixed, however I completely missed out that ``typeof`` doesn't catch things like null in JSON since they are considered an [``object``](https://stackoverflow.com/a/8511350) in JavaScript.

Also arrays are not used for messages in Rotom so those were also checked and dropped in this PR.

Snippet that replicates the crash:
```js
const WebSocket = require("ws");

const ws = new WebSocket("ws://localhost:7070/control", {
    headers: {
        "x-rotom-secret": ""
    }
});

ws.on("open", () => {
    ws.send("null");
});
```