### PR TITLE
Make spammy logs slightly less spammy. Clarify out-of-devices warning.

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -288,7 +288,8 @@ wssController.on('connection', (ws, req) => {
     // no devices found, return the original one back to pool
     unallocatedConnections.push(nextSpareWorkerId);
     log.info(
-      `CONTROLLER: New connection from ${req.socket.remoteAddress} - no Devices available outside cooldown, rejecting`,
+      `CONTROLLER: New connection from ${req.socket.remoteAddress} - no Devices available outside cooldown, which is set to ${config.monitor.deviceCooldown} seconds.
+      If you're seeing this, either increase the number of devices, reduce the demand for workers, or decrease the device cooldown. Rejecting connection.`,
     );
     // error!
     ws.close(3001, 'All devices are in cooldown');

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -288,8 +288,8 @@ wssController.on('connection', (ws, req) => {
     // no devices found, return the original one back to pool
     unallocatedConnections.push(nextSpareWorkerId);
     log.info(
-      `CONTROLLER: New connection from ${req.socket.remoteAddress} - no Devices available outside cooldown, which is set to ${config.monitor.deviceCooldown} seconds.
-      If you're seeing this, either increase the number of devices, reduce the demand for workers, or decrease the device cooldown. Rejecting connection.`,
+      `CONTROLLER: New connection from ${req.socket.remoteAddress} - no Devices available outside cooldown, which is set to ${config.monitor.deviceCooldown} seconds. `+
+      `If you're seeing this, either increase the number of devices, reduce the demand for workers, or decrease the device cooldown. Rejecting connection.`,
     );
     // error!
     ws.close(3001, 'All devices are in cooldown');

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -259,7 +259,7 @@ wssController.on('connection', (ws, req) => {
   const firstSpareWorkerId = nextSpareWorkerId;
   do {
     const mainDeviceId = identifyControlChannelFromWorkerId(nextSpareWorkerId);
-    log.info(`CONTROLLER: Found ${mainDeviceId} connects to workerId ${nextSpareWorkerId}`);
+    log.debug(`CONTROLLER: Found ${mainDeviceId} connects to workerId ${nextSpareWorkerId}`);
     if (mainDeviceId == null) {
       log.info(`CONTROLLER: Warning - found ${nextSpareWorkerId} in pool with no record of main device`);
       unallocatedConnections.push(nextSpareWorkerId);


### PR DESCRIPTION
When running rotom with a high workers-to-devices ratio (in my case nearly 200) and with a device cooldown enabled (my mistake, and fixed now) the logs are **extremely** spammy, with hundreds or thousands of the same message printed per second, since it is printed once per unavailable worker, per connection attempt.

This PR moves the extremely spammy message down to `debug` level, and also makes the error printed to the log more concise and offers troubleshooting instructions so that future users are more easily able to resolve it.

Example of two seconds of the log spam in question: 
[rotom-spam.log](https://github.com/user-attachments/files/22876641/rotom-spam.log)

I've tested this change by building it into [a docker container](https://hub.docker.com/repository/docker/compl3m3nt/rotom/tags/v2/sha256-f4123df24ad2c5600433ed95dff49534ee0bcab918532e50b53a5749f107c518) and running it on my unown stack.